### PR TITLE
Add custom share route to join game

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -12,6 +12,20 @@ class PlayersController < ApplicationController
     cookies.delete(:player_id)
   end
 
+  def new_with_code
+    cookies.delete(:player_id)
+    game = Game.find_by(code: params[:game_code])
+
+    if game.present? && !game.activated?
+      @player = Player.new(game: game)
+    else
+      redirect_to join_game_path
+      return
+    end
+
+    render :new
+  end
+
   def create
     @player = Player.new(name: player_params[:name], game_id: @game&.id)
 

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -40,6 +40,10 @@ module GamesHelper
     '<i class="far fa-handshake"></i>'
   end
 
+  def share_link(game)
+    "#{root_url}play/#{game.code}"
+  end
+
   private
 
   def winner_intro(winner)

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -27,7 +27,7 @@
           </div>
 
           <div class="content">
-            <p>Share Link: <%= link_to join_game_url, join_game_url %></p>
+            <p>Share Link: <%= link_to share_link(game), share_link(game) %></p>
             <p>
               Adult Content? <%= boolean_check_or_x(game.adult_content_permitted?) %> |
               Players Ready? <%= boolean_check_or_x(game.players_ready?) %> |

--- a/app/views/players/new.html.erb
+++ b/app/views/players/new.html.erb
@@ -4,7 +4,7 @@
 
     <div class='field'>
       <%= form.label :game_code %>
-      <%= form.text_field :game_code, autofocus: true, placeholder: 'Ex: HMJY', class: 'input' %>
+      <%= form.text_field :game_code, value: @player&.game&.code, placeholder: 'Ex: HMJY', class: 'input' %>
       <small id='error_helper_text' class="form-text error-helper-text hidden">Invalid Game Code</small>
     </div>
 

--- a/app/views/shared/_errors.html.erb
+++ b/app/views/shared/_errors.html.erb
@@ -1,10 +1,10 @@
 <% if object.errors.any? %>
   <div id="error_explanation">
-    <h2><%= pluralize(object.errors.count, "error") %> prohibited this object from being saved:</h2>
+    <h2 class='title is-h2 has-text-danger'><%= pluralize(object.errors.count, "error") %> prohibited this object from being saved:</h2>
 
-    <ul>
+    <ul class='mb-5'>
     <% object.errors.full_messages.each do |message| %>
-      <li><%= message %></li>
+      <li class='has-text-danger'><%= message %></li>
     <% end %>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   resources :players, only: [:new, :create]
   get 'play', to: 'players#new', as: 'join_game'
+  get 'play/:game_code', to: 'players#new_with_code', as: 'join_game_with_code'
   post 'play', to: 'games#players_ready', as: 'players_ready'
 
   resources :games do


### PR DESCRIPTION
## Problems Solved
* closes #9 
* creates custom join link so a new player can join the game without having to enter a code
* players can still join by entering a code
* new players can't join a game that has already started
* error messages on new player page now have bulma styles

