### PR TITLE
Cant join after game start

### DIFF
--- a/app/controllers/decks_controller.rb
+++ b/app/controllers/decks_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DecksController < ApplicationController
   before_action :set_deck, only: %i[edit update destroy]
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -74,7 +74,7 @@ class GamesController < ApplicationController
     GameChannel.broadcast_to @game,
                              game_code: @game.code,
                              player_name: 'undefined',
-                             game_activated: @game.activated?,
+                             game_activated: @game.active?,
                              destination_url: new_game_round_submission_url(@game, @game.rounds.first)
 
     redirect_to new_game_round_submission_url(@game, @game.rounds.first)

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -80,6 +80,9 @@ class GamesController < ApplicationController
     redirect_to new_game_round_submission_url(@game, @game.rounds.first)
   end
 
+  def game_in_progress
+  end
+
   private
 
   def set_game

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -16,7 +16,7 @@ class PlayersController < ApplicationController
     cookies.delete(:player_id)
     game = Game.find_by(code: params[:game_code])
 
-    if game.present? && !game.activated?
+    if game.present? && !game.active?
       @player = Player.new(game: game)
     else
       redirect_to join_game_path

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -37,9 +37,9 @@ class PlayersController < ApplicationController
         cookies[:game_id] = { value: @game.id, expires: 1.day.from_now }
 
         GameChannel.broadcast_to @game,
-        game_code: @game.code,
-        player_name: @player.name,
-        game_activated: @game.active?
+                                 game_code: @game.code,
+                                 player_name: @player.name,
+                                 game_activated: @game.active?
 
         redirect_to game_players_url(@game)
       else

--- a/app/helpers/games_helper.rb
+++ b/app/helpers/games_helper.rb
@@ -40,6 +40,14 @@ module GamesHelper
     emojis
   end
 
+  def overall_votes_as_emojis(player)
+    emojis = ''
+    player.votes.times do |_vote|
+      emojis += '✅ '
+    end
+    emojis
+  end
+
   def winner_icon
     "<i class='fas fa-crown'></i>"
   end

--- a/app/helpers/rounds_helper.rb
+++ b/app/helpers/rounds_helper.rb
@@ -19,4 +19,8 @@ module RoundsHelper
   def hidden_class(round)
     'hidden' unless round.complete?
   end
+
+  def display_current_round_of_total(round)
+    "#{round.number} of #{round.game.total_rounds}"
+  end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -58,8 +58,8 @@ class Game < ApplicationRecord
     end
   end
 
-  def activated?
     created_at.to_date >= Time.zone.now.to_date && players_ready?
+  def active?
   end
 
   def date

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -58,8 +58,8 @@ class Game < ApplicationRecord
     end
   end
 
-    created_at.to_date >= Time.zone.now.to_date && players_ready?
   def active?
+    players_ready? && !expired?
   end
 
   def date
@@ -105,6 +105,13 @@ class Game < ApplicationRecord
   def submissions
     round_ids = rounds.pluck(:id)
     Submission.where(round_id: round_ids)
+  end
+
+  def total_rounds
+    # max_rounds becomes inaccurate if it has been overridden
+    # by a smaller number of available_questions.
+    # this only works if game is in-play.
+    rounds.length
   end
 
   private

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -67,10 +67,11 @@ class Game < ApplicationRecord
   end
 
   def generate_rounds
-    round_numbers = (1..max_rounds).to_a
-    questions = generate_questions
+    available_questions = generate_questions
+    rounds_count = available_questions.length < max_rounds ? available_questions.length : max_rounds
+    round_numbers = (1..rounds_count).to_a
 
-    questions.each do |question|
+    available_questions.each do |question|
       rounds.create!(
         number: round_numbers.shift,
         question_id: question.id

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -54,7 +54,7 @@ class Game < ApplicationRecord
     if complete?
       rounds.last.submissions.last.created_at < 30.minutes.ago
     else
-      created_at < 2.hours.ago
+      created_over_2_hours_ago?
     end
   end
 
@@ -96,6 +96,10 @@ class Game < ApplicationRecord
 
   def tied?
     winner.blank?
+  end
+
+  def created_over_2_hours_ago?
+    created_at <= 2.hours.ago
   end
 
   private

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -102,6 +102,11 @@ class Game < ApplicationRecord
     created_at <= 2.hours.ago
   end
 
+  def submissions
+    round_ids = rounds.pluck(:id)
+    Submission.where(round_id: round_ids)
+  end
+
   private
 
   def generate_code

--- a/app/models/game_deck.rb
+++ b/app/models/game_deck.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: game_decks

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -37,4 +37,8 @@ class Player < ApplicationRecord
     winning_rounds = game.rounds.select { |round| round.winner == self }
     winning_rounds.length
   end
+
+  def votes
+    game.submissions.for_player(self)
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -40,4 +40,8 @@ class Question < ApplicationRecord
   def self.without_adult_content
     active.where.not(adult_rating: true)
   end
+
+  def active?
+    archived == false
+  end
 end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -49,6 +49,10 @@ class Round < ApplicationRecord
     results.sort_by { |_candidate, voters| -voters.count }
   end
 
+  def last?
+    number == game.total_rounds
+  end
+
   private
 
   def candidate_names(candidate_ids)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -32,4 +32,8 @@ class Submission < ApplicationRecord
   validates :voter, uniqueness: { scope: :round_id,
                                   message: 'you only get to vote once per round' }
   # rubocop:enable Rails/UniqueValidationWithoutIndex
+
+  def self.for_player(candidate)
+    where(candidate_id: candidate.id).length
+  end
 end

--- a/app/views/decks/index.html.erb
+++ b/app/views/decks/index.html.erb
@@ -15,7 +15,7 @@
           <%= link_to "#{deck.name} Deck", deck_questions_path(deck) %>
         </p>
         <p class="subtitle">
-          Questions: <%= deck.questions.length %>
+          Questions: <%= deck.questions.active.length %>
         </p>
       </div>
       <footer class="card-footer">

--- a/app/views/games/game_in_progress.html.erb
+++ b/app/views/games/game_in_progress.html.erb
@@ -2,4 +2,6 @@
   <h1 class='title is-h1'>😕</h1>
   <h1 class='title branded centered'>Sorry!<br>This game is no longer accepting players.</h1>
   <p>You'll have to wait for another game to start.</p>
+
+  <%= link_to ('<i class="fas fa-gamepad mr-2"></i>'.html_safe + 'Join Another Game'), join_game_path, class: "#{button_classes} mt-5" %><br>
 </section>

--- a/app/views/games/game_in_progress.html.erb
+++ b/app/views/games/game_in_progress.html.erb
@@ -1,0 +1,5 @@
+<section class='section centered'>
+  <h1 class='title is-h1'>😕</h1>
+  <h1 class='title branded centered'>Sorry!<br>This game is no longer accepting players.</h1>
+  <p>You'll have to wait for another game to start.</p>
+</section>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -14,11 +14,17 @@
           <% unless @game.tied? %>
             Winning <%= @game.winner.rounds_won %> out of <%= pluralize(@game.rounds.length, 'round') %>,<br>
           <% end %>
-          the winner is...
+          the "winner" is...
         </h2>
         <h1 class="winner branded">
             👑💩 <%= display_winner(@game) %>! 🎊🎉
         </h1>
+
+        <% unless @game.tied? %>
+          <h2 class="subtitle branded mt-5">
+            😏Good job, <%= display_winner(@game) %>. You're a real winner. 😂
+          </h2>
+        <% end %>
       </div>
     </div>
   </center>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -34,13 +34,27 @@
   <div class='columns'>
     <div class='column'>
       <section class='section'>
-        <h2 class='title is-3 branded'>Winners by Round</h2>
+        <h2 class='title is-3 branded'>Rounds Won</h2>
         <table>
           <tbody>
             <% @game.players.each do |player| %>
             <tr>
               <td style='padding-right: 15px;'><span class='title is-5 branded'><%= player.name %></span></td>
               <td><%= rounds_won_as_emojis(player) %></td>
+            </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </section>
+
+      <section class='section'>
+        <h2 class='title is-3 branded'>Total Votes Across All Questions</h2>
+        <table>
+          <tbody>
+            <% @game.players.each do |player| %>
+            <tr>
+              <td style='padding-right: 15px;'><span class='title is-5 branded'><%= player.name %></span></td>
+              <td><%= overall_votes_as_emojis(player) %></td>
             </tr>
             <% end %>
           </tbody>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -16,12 +16,12 @@
           <% end %>
           the "winner" is...
         </h2>
-        <h1 class="winner branded">
+        <h1 class="winner branded mt-2 mb-5">
             👑💩 <%= display_winner(@game) %>! 🎊🎉
         </h1>
 
         <% unless @game.tied? %>
-          <h2 class="subtitle branded mt-5">
+          <h2 class="subtitle branded">
             😏Good job, <%= display_winner(@game) %>. You're a real winner. 😂
           </h2>
         <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -22,7 +22,7 @@
 
         <% unless @game.tied? %>
           <h2 class="subtitle branded">
-            😏Good job, <%= display_winner(@game) %>. You're a real winner. 😂
+            😏 Good job, <%= display_winner(@game) %>. You're a real winner. 😂
           </h2>
         <% end %>
       </div>

--- a/app/views/players/index.html.erb
+++ b/app/views/players/index.html.erb
@@ -6,8 +6,7 @@
     <% end %>
   </div>
 
-    <p class='mt-6'>Is everybody in?</p>
-    <%= link_to 'Start Game!', players_ready_path(id: @game.id), method: :post, class: button_classes %>
   <% unless @game.active? %>
+    <%= link_to 'Everybody is Ready! Start the Game!', players_ready_path(id: @game.id), method: :post, class: "mt-6 #{button_classes}" %>
   <% end %>
 </section>

--- a/app/views/players/index.html.erb
+++ b/app/views/players/index.html.erb
@@ -6,8 +6,8 @@
     <% end %>
   </div>
 
-  <% unless @game.activated? %>
     <p class='mt-6'>Is everybody in?</p>
     <%= link_to 'Start Game!', players_ready_path(id: @game.id), method: :post, class: button_classes %>
+  <% unless @game.active? %>
   <% end %>
 </section>

--- a/app/views/rounds/show.html.erb
+++ b/app/views/rounds/show.html.erb
@@ -1,7 +1,7 @@
 <div id='round-channel-id' data-round-id="<%= @round.id %>"></div>
 
 <div class='centered'>
-  <p>Question <%= @round.number %> of <%= @round.game.max_rounds %></p>
+  <p>Question <%= display_current_round_of_total(@round) %></p>
   <h2 class='title is-2'><%= @round.question.text %></h2>
 
   <!-- if we're waiting for results... -->

--- a/app/views/rounds/show.html.erb
+++ b/app/views/rounds/show.html.erb
@@ -22,7 +22,7 @@
     <h1 class='branded round-winner-name' id='round-winner'><%= display_winner(@round) %></h1>
 
     <section class='mt-6'>
-      <% if @round.number == @round.game.max_rounds || @round.game.complete? %>
+      <% if @round.last? || @round.game.complete? %>
         <%= link_to "Let's see who won the game!", game_path(@round.game), class: button_classes %>
       <% else %>
         <%= link_to 'Next Question', next_round_submission(@round), class: button_classes %>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -1,6 +1,6 @@
 <div class='centered'>
   <h1 class='title branded'><%= @player&.name %>, cast your vote!</h1>
-  <p>Question <%= @round.number %> of <%= @game.max_rounds %></p>
+  <p>Question <%= display_current_round_of_total(@round) %></p>
   <h2 class='title is-2'><%= @round.question.text %></h2>
 
   <%= form_with(model: [@game, @round, @submission], local: true) do |form| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,11 +16,13 @@ Rails.application.routes.draw do
   post 'play', to: 'games#players_ready', as: 'players_ready'
 
   resources :games do
+    get 'in_progress', to: 'games#game_in_progress', as: 'in_progress'
     resources :players, only: [:index]
     resources :rounds, only: [:show] do
       resources :submissions, only: [:new, :create]
     end
   end
+
   resources :decks do
     resources :questions, only: [:index, :new, :create, :edit, :update ]
   end

--- a/spec/channels/game_channel_spec.rb
+++ b/spec/channels/game_channel_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe GameChannel, type: :channel do

--- a/spec/channels/player_channel_spec.rb
+++ b/spec/channels/player_channel_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe PlayerChannel, type: :channel do

--- a/spec/channels/round_channel_spec.rb
+++ b/spec/channels/round_channel_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe RoundChannel, type: :channel do

--- a/spec/factories/game_decks.rb
+++ b/spec/factories/game_decks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :game_deck do
     game { nil }

--- a/spec/factories/submissions.rb
+++ b/spec/factories/submissions.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :submission do
-    round { create(:round) }
+    round
     candidate_id { create(:player).id }
     voter_id { create(:player).id }
   end

--- a/spec/models/deck_spec.rb
+++ b/spec/models/deck_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Deck, type: :model do

--- a/spec/models/game_deck_spec.rb
+++ b/spec/models/game_deck_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe GameDeck, type: :model do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -133,18 +133,33 @@ RSpec.describe Game, type: :model do
     let(:question2) { create(:question, deck: deck2) }
     let(:question3) { create(:question, deck: deck2) }
 
-    it 'generates the max_rounds for a game' do
+    it 'does not create more rounds than there are available questions' do
       question1
       question2
-      question3
-      expected_rounds = 3
+      question_count = 2
+      game_max_rounds = 3
       game = create(:game,
                     user: user,
                     deck_ids: [deck1.id, deck2.id],
-                    max_rounds: expected_rounds)
+                    max_rounds: game_max_rounds)
       game.generate_rounds
 
-      expect(game.rounds.size).to eq(expected_rounds)
+      expect(game.rounds.size).to eq(question_count)
+    end
+
+    it "does not create more rounds than the game's max_rounds" do
+      question1
+      question2
+      question3
+      question_count = 3
+      game_max_rounds = 2
+      game = create(:game,
+                    user: user,
+                    deck_ids: [deck1.id, deck2.id],
+                    max_rounds: game_max_rounds)
+      game.generate_rounds
+
+      expect(game.rounds.size).to eq(game_max_rounds)
     end
 
     it 'excludes adult questions when requested' do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Game, type: :model do
   let(:deck) { create(:deck, user: user) }
   let(:question) { create(:question, deck: deck) }
   let(:round) { create(:round, game: game, question: question) }
-  let(:player1) { game.player.first }
-  let(:player2) { game.player.second }
-  let(:player3) { game.player.third }
+  let(:player1) { game.players.first }
+  let(:player2) { game.players.second }
+  let(:player3) { game.players.third }
 
   before :each do
     game
@@ -278,6 +278,34 @@ RSpec.describe Game, type: :model do
              voter_id: player3.id)
 
       expect(game.winner).to eq(player1)
+    end
+  end
+
+  describe 'submissions' do
+    it 'returns all submissions for a game' do
+      submission1 = create(:submission, round: round, candidate_id: player1.id, voter_id: player2.id)
+      submission2 = create(:submission, round: round, candidate_id: player2.id, voter_id: player1.id)
+
+      expect(game.submissions).to include(submission1)
+      expect(game.submissions).to include(submission2)
+    end
+
+    it 'excludes submissions that are not for this game' do
+      game2 = create(:game, user: user)
+      question2 = create(:question, deck: deck)
+      round_g2 = create(:round, game: game2, question: question2)
+      player1 = create(:player, game: game2)
+      player2 = create(:player, game: game2)
+
+      submission1 = create(:submission, round: round, candidate_id: player1.id, voter_id: player2.id)
+      submission2 = create(:submission, round: round, candidate_id: player2.id, voter_id: player1.id)
+      submission3 = create(:submission, round: round_g2, candidate_id: player1.id, voter_id: player2.id)
+      submission4 = create(:submission, round: round_g2, candidate_id: player2.id, voter_id: player1.id)
+
+      expect(game2.submissions).to_not include(submission1)
+      expect(game2.submissions).to_not include(submission2)
+      expect(game2.submissions).to include(submission3)
+      expect(game2.submissions).to include(submission4)
     end
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe Game, type: :model do
       game.generate_rounds
 
       expect(game.rounds.size).to eq(question_count)
+      expect(game.rounds.size).to_not eq(game_max_rounds)
     end
 
     it "does not create more rounds than the game's max_rounds" do
@@ -185,6 +186,7 @@ RSpec.describe Game, type: :model do
       game.generate_rounds
 
       expect(game.rounds.size).to eq(game_max_rounds)
+      expect(game.rounds.size).to_not eq(question_count)
     end
 
     it 'excludes adult questions when requested' do

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -308,4 +308,9 @@ RSpec.describe Game, type: :model do
       expect(game2.submissions).to include(submission4)
     end
   end
+
+  describe 'total_rounds' do
+    xit 'returns a count of rounds that are in-play for a game' do
+    end
+  end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -90,8 +90,33 @@ RSpec.describe Game, type: :model do
     end
   end
 
-  describe 'activated?' do
-    xit '' do
+  describe 'active?' do
+    it 'returns true if players are ready and the game is not expired' do
+      game = create(:game, players_ready: true)
+      allow(game).to receive(:expired?).and_return(false)
+
+      expect(game.active?).to be(true)
+    end
+
+    it 'returns false if players are ready and the game is expired' do
+      game = create(:game, players_ready: true)
+      allow(game).to receive(:expired?).and_return(true)
+
+      expect(game.active?).to be(false)
+    end
+
+    it 'returns false if players are not ready and the game is not expired' do
+      game = create(:game, players_ready: false)
+      allow(game).to receive(:expired?).and_return(false)
+
+      expect(game.active?).to be(false)
+    end
+
+    it 'returns false if players are not ready and the game is expired' do
+      game = create(:game, players_ready: false)
+      allow(game).to receive(:expired?).and_return(true)
+
+      expect(game.active?).to be(false)
     end
   end
 

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -10,6 +10,56 @@ RSpec.describe Player, type: :model do
 
   context 'validations' do
     it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:game_id) }
     # it { should validate_uniqueness_of(:name).scoped_to(:game_id) }
+  end
+
+  # Setup needed for all specs
+  let(:user) { create(:user) }
+  let(:game) { create(:game, user: user) }
+  let(:deck) { create(:deck, user: user) }
+  let(:question1) { create(:question, deck: deck) }
+  let(:question2) { create(:question, deck: deck) }
+  let(:round1) { create(:round, game: game, question: question1, number: 1) }
+  let(:round2) { create(:round, game: game, question: question2, number: 2) }
+  let(:player1) { create(:player, game: game) }
+  let(:player2) { create(:player, game: game) }
+  let(:player3) { create(:player, game: game) }
+
+  describe 'rounds_won' do
+    it 'returns a count of rounds won in that game' do
+      create(:submission, round: round1, candidate_id: player1.id, voter_id: player2.id)
+      create(:submission, round: round1, candidate_id: player1.id, voter_id: player1.id)
+
+      expect(player1.rounds_won).to eq(1)
+      expect(player2.rounds_won).to eq(0)
+    end
+
+    it 'handles multiple rounds' do
+      create(:submission, round: round1, candidate_id: player1.id, voter_id: player2.id)
+      create(:submission, round: round1, candidate_id: player1.id, voter_id: player1.id)
+      create(:submission, round: round2, candidate_id: player1.id, voter_id: player2.id)
+      create(:submission, round: round2, candidate_id: player1.id, voter_id: player1.id)
+
+      expect(player1.rounds_won).to eq(2)
+      expect(player2.rounds_won).to eq(0)
+    end
+
+  end
+
+  describe 'votes' do
+    it 'returns the number of votes a player had in the whole game' do
+      create(:submission, round: round1, candidate_id: player1.id, voter_id: player2.id)
+      create(:submission, round: round1, candidate_id: player1.id, voter_id: player1.id)
+      create(:submission, round: round1, candidate_id: player2.id, voter_id: player3.id)
+
+      create(:submission, round: round2, candidate_id: player1.id, voter_id: player2.id)
+      create(:submission, round: round2, candidate_id: player3.id, voter_id: player1.id)
+      create(:submission, round: round2, candidate_id: player2.id, voter_id: player3.id)
+
+      expect(player1.votes).to eq(3)
+      expect(player2.votes).to eq(2)
+      expect(player3.votes).to eq(1)
+    end
   end
 end

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Player, type: :model do
       expect(player1.rounds_won).to eq(2)
       expect(player2.rounds_won).to eq(0)
     end
-
   end
 
   describe 'votes' do

--- a/spec/models/round_spec.rb
+++ b/spec/models/round_spec.rb
@@ -120,4 +120,27 @@ RSpec.describe Round, type: :model do
       expect(round.results_by_candidate).to eq(expected_results)
     end
   end
+
+  describe 'last?' do
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user: user) }
+    let(:deck) { create(:deck, user: user) }
+    let(:question1) { create(:question, deck: deck) }
+    let(:question2) { create(:question, deck: deck) }
+    let(:round1) { create(:round, game: game, question: question1, number: 1) }
+    let(:round2) { create(:round, game: game, question: question2, number: 2) }
+
+    before do
+      round1
+      round2
+    end
+
+    it 'returns true when it is the last round of the game' do
+      expect(round1.last?).to be(false)
+    end
+
+    it 'returns false when it is not the last round of the game' do
+      expect(round2.last?).to be(true)
+    end
+  end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -13,4 +13,47 @@ RSpec.describe Submission, type: :model do
     # wip
     # validates :voter, uniqueness: { scope: :round_id, message: "you only get to vote once per round" }
   end
+
+  describe 'self.for_player' do
+    let(:user) { create(:user) }
+    let(:game) { create(:game, user: user) }
+    let(:deck) { create(:deck, user: user) }
+    let(:question1) { create(:question, deck: deck) }
+    let(:question2) { create(:question, deck: deck) }
+    let(:round1) { create(:round, game: game, question: question1, number: 1) }
+    let(:round2) { create(:round, game: game, question: question2, number: 2) }
+    let(:player1) { create(:player, game: game) }
+    let(:player2) { create(:player, game: game) }
+    let(:player3) { create(:player, game: game) }
+
+    it 'includes submissions for a specific candidate' do
+      create(:submission, round: round1, candidate_id: player1.id, voter_id: player2.id)
+      candidate_submissions = described_class.for_player(player1)
+
+      expect(candidate_submissions).to eq(1)
+    end
+
+    it 'excludes submissions not for that candidate' do
+      create(:submission, round: round1, candidate_id: player2.id, voter_id: player3.id)
+      candidate_submissions = described_class.for_player(player1)
+
+      expect(candidate_submissions).to eq(0)
+    end
+
+    it "doesn't care about who voted for that candidate" do
+      create(:submission, round: round1, candidate_id: player2.id, voter_id: player1.id)
+      candidate_submissions = described_class.for_player(player1)
+
+      expect(candidate_submissions).to eq(0)
+    end
+
+    it "includes votes across all rounds" do
+      create(:submission, round: round1, candidate_id: player1.id, voter_id: player1.id)
+      create(:submission, round: round2, candidate_id: player1.id, voter_id: player2.id)
+      create(:submission, round: round2, candidate_id: player2.id, voter_id: player3.id)
+      candidate_submissions = described_class.for_player(player1)
+
+      expect(candidate_submissions).to eq(2)
+    end
+  end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Submission, type: :model do
       expect(candidate_submissions).to eq(0)
     end
 
-    it "includes votes across all rounds" do
+    it 'includes votes across all rounds' do
       create(:submission, round: round1, candidate_id: player1.id, voter_id: player1.id)
       create(:submission, round: round2, candidate_id: player1.id, voter_id: player2.id)
       create(:submission, round: round2, candidate_id: player2.id, voter_id: player3.id)


### PR DESCRIPTION
## Problems Solved
* We had a crappy bug where a person joined the game late and it messed up *allthethings*. Most notably, the submissions count got wacky. We decided that it's not really fair for a person to join the game late (and they can't leave early), so we solved this by routing latecomers to a consolation page.
* Another bug! Yay! Since `decks` are a new concept, it had not occurred to me that a person max set a `max_rounds` for a game that is a higher number than the available questions. This code fixes it so that the rounds can never exceed the number of available questions or the max rounds for the game.

## Screenshots
New consolation page
<img width="612" alt="Screen Shot 2020-10-25 at 2 08 43 PM" src="https://user-images.githubusercontent.com/8680712/97116515-a659b080-16cb-11eb-9167-3c98bdc180ad.png">

New total votes section
<img width="570" alt="Screen Shot 2020-10-25 at 2 10 53 PM" src="https://user-images.githubusercontent.com/8680712/97116546-eb7de280-16cb-11eb-8ce0-56ca9b249758.png">


## Things Learned
* feature specs may be useful here. i'm wondering if i can get away with view specs.
