### PR TITLE
Add helper text to decks index

### DIFF
--- a/app/views/decks/index.html.erb
+++ b/app/views/decks/index.html.erb
@@ -1,13 +1,15 @@
-<% content_for(:title, 'Questions') %>
+<% content_for(:title, 'Decks') %>
 
 <header class='level'>
-  <h1 class='title is-1 level-left'>Question Decks</h1>
+  <div>
+    <h1 class='title is-1 level-left'>Custom Decks</h1>
+    <p>You automatically have access to the default BlameGame decks. You can create additional custom decks and questions here.</p>
+  </div>
   <%= link_to '+ New Deck', new_deck_path, class: "level-right #{button_classes}" %>
 </header>
 
+
 <section class='section form-narrow'>
-
-
   <% @decks.order(:name).each do |deck| %>
     <div class="card mb-5">
       <div class="card-content">

--- a/app/views/shared/navbar/_signed_in.html.erb
+++ b/app/views/shared/navbar/_signed_in.html.erb
@@ -1,5 +1,5 @@
 <% if current_user %>
   <%= link_to '+ New Game', new_game_path, class: 'navbar-item' %>
   <%= link_to 'Games', games_path, class: 'navbar-item' %>
-  <%= link_to 'Question Decks', decks_path, class: 'navbar-item' %>
+  <%= link_to 'Custom Decks', decks_path, class: 'navbar-item' %>
 <% end %>


### PR DESCRIPTION
## Problems Solved
* It wasn't clear to new users that they have access to decks -- and don't need to build them out before playing. Adding this copy makes it a bit more clear.

## Screenshots
<img width="1049" alt="Screen Shot 2020-11-16 at 7 10 11 PM" src="https://user-images.githubusercontent.com/8680712/99327384-71aac600-283f-11eb-9b39-e5cad9cef713.png">

